### PR TITLE
Fix #2 from hydrogen-launcher

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,16 @@ function _getWindowsCommand(command, cwd, terminal) {
     powershell: '-NoExit'
   };
   var term = terminal.toLowerCase().trim();
-  return `start ${terminal} ${args[term]} "${_joinCommands(cwd, command, ' & ')}"`;
+
+  // '/k' is default
+  var argument = '/k';
+  if (args.hasOwnProperty(term)) {
+    argument = args[term];
+  } else if (args.hasOwnProperty(term.replace(/.exe$/, ''))) { //In case of '.exe' suffix
+    argument = args[term.replace(/.exe$/, '')];
+  }
+
+  return `start ${terminal} ${argument} "${_joinCommands(cwd, command, ' & ')}"`;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -64,7 +64,14 @@ function _getLinuxCommand(command, cwd, terminal) {
 }
 
 function _getWindowsCommand(command, cwd, terminal) {
-  return `start ${terminal} /k "${_joinCommands(cwd, command, ' & ')}"`;
+  // Every terminal on Windows has its own arguments.
+  var args = {
+    cmd: '/k',
+    cmder: '/START',
+    powershell: '-NoExit'
+  };
+  var term = terminal.toLowerCase().trim();
+  return `start ${terminal} ${args[term]} "${_joinCommands(cwd, command, ' & ')}"`;
 }
 
 /**


### PR DESCRIPTION
Link to issue: https://github.com/lgeiger/hydrogen-launcher/issues/2

There are a lot more Terminals on Windows and a lot of them are actually used a lot because cmd is not that popular. So there may be a need for adding more terminals.