### PR TITLE
Point directly to the docs on github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ term.launchJupyter('<path-to-connection-file>', 'Desktop', 'iTerm.app');
 
 ## Documentation
 
-The full API documentation can be found [here](http://nteract.io/term-launcher/).
+[API Documentation](https://nteract.github.io/term-launcher/).


### PR DESCRIPTION
Our base site isn't handling redirects to the github.io page properly so I updated the URL in the README.